### PR TITLE
Update Gemini model to `gemini-3.1-flash-lite`

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -93,7 +93,7 @@ export async function generateCardsWithGemini(prompt: string): Promise<Array<{ t
   }
 
   const ai = new GoogleGenAI({ apiKey })
-  const model = 'gemini-2.5-flash-lite'
+  const model = 'gemini-3.1-flash-lite'
   const contents = [
     {
       role: 'user',
@@ -137,7 +137,7 @@ export async function generateMoreCardsWithGemini(deckName: string, existingCard
   }
 
   const ai = new GoogleGenAI({ apiKey })
-  const model = 'gemini-2.5-flash-lite'
+  const model = 'gemini-3.1-flash-lite'
   const cardsContext = existingCards.map((c) => `- Title: ${c.title}\n  Content: ${c.content}`).join('\n')
   const contents = [
     {
@@ -188,7 +188,7 @@ export async function generateDeckWithAI(topic: string): Promise<{ name: string;
   }
 
   const ai = new GoogleGenAI({ apiKey })
-  const model = 'gemini-2.5-flash-lite'
+  const model = 'gemini-3.1-flash-lite'
   const contents = [
     {
       role: 'user',

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -93,7 +93,7 @@ export async function generateCardsWithGemini(prompt: string): Promise<Array<{ t
   }
 
   const ai = new GoogleGenAI({ apiKey })
-  const model = 'gemini-3.1-flash-lite'
+  const model = 'gemini-3.1-flash-lite-preview'
   const contents = [
     {
       role: 'user',
@@ -137,7 +137,7 @@ export async function generateMoreCardsWithGemini(deckName: string, existingCard
   }
 
   const ai = new GoogleGenAI({ apiKey })
-  const model = 'gemini-3.1-flash-lite'
+  const model = 'gemini-3.1-flash-lite-preview'
   const cardsContext = existingCards.map((c) => `- Title: ${c.title}\n  Content: ${c.content}`).join('\n')
   const contents = [
     {
@@ -188,7 +188,7 @@ export async function generateDeckWithAI(topic: string): Promise<{ name: string;
   }
 
   const ai = new GoogleGenAI({ apiKey })
-  const model = 'gemini-3.1-flash-lite'
+  const model = 'gemini-3.1-flash-lite-preview'
   const contents = [
     {
       role: 'user',


### PR DESCRIPTION
### Motivation
- Upgrade the Gemini model identifier to `gemini-3.1-flash-lite` so AI generation uses the latest 3.1 Flash Lite improvements.

### Description
- Replace `gemini-2.5-flash-lite` with `gemini-3.1-flash-lite` in `src/lib/gemini.ts` for the functions `generateCardsWithGemini`, `generateMoreCardsWithGemini`, and `generateDeckWithAI`.

### Testing
- Ran `npm test` (Vitest) and all automated tests passed: 3 test files, 33 tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3715987688333bd0c6bfcfb365b82)